### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # GStreamer H264 Encryption Plugin
 This is an experimental plugin designed to offer GStreamer elements for H.264 encryption/decryption while preserving the H.264 structure with nalu and slice headers intact.
 The goal is to enable the playback of the encrypted stream even if properties such as stream-format or alignment are altered.
-This capability allows secure video streaming over potentially insecure channels or storage in the MP4 format, with the added advantage of recoverability in the face of packet loss, common in UDP streams.
+This capability allows secure video streaming over potentially insecure channels or storage in the MP4 format while not losing recoverability in the face of packet loss, which is common in UDP based streams (ie. RTP).
 
 Note that this solution requires both encrypting and decrypting sides to be using this plugin. Thus, it is not compatible with existing tools without advanced alterations. You might want to look at DRM and Common Encryption for that.
 
 The current implementation supports 128-bit AES encryption in ECB, CBC, and CTR modes. Although the IV ([Initialization Vector](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Initialization_vector_(IV))) and key are currently static, there are plans to enhance security by introducing dynamic IVs in future iterations. 
 
-For AES implementation used [Tiny AES in C](https://github.com/kokke/tiny-AES-c/tree/master) library.
+This project utilizes [Tiny AES in C](https://github.com/kokke/tiny-AES-c/tree/master) library for its AES encryption implementation.
+
+Minimum GStreamer version requirement is 1.23.1.
+
+Developed on ubuntu:22.04 docker image and GStreamer 1.23.1.
 
 > [!WARNING]
 > Use it at your own risk!
@@ -16,12 +20,7 @@ For AES implementation used [Tiny AES in C](https://github.com/kokke/tiny-AES-c/
 - Add CMake for ease
 - ECB mode does not use IV. However, IV is generated and inserted into the stream regardless. Remove it.
 
-## Issues
-No known issues at the moment.
-
 ## Example Pipelines:
-Note that decryptor IV has to be present but not used.
-
 - Encrypt and decrypt in counter (CTR) mode:
 ```shell
 gst-launch-1.0 videotestsrc pattern=ball ! nvh264enc ! \
@@ -53,26 +52,6 @@ gst-launch-1.0 videotestsrc pattern=ball ! nvh264enc ! \
     h264decrypt key=01234567012345670123456701234567 encryption-mode=aes-cbc ! \
     h264decrypt key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA encryption-mode=aes-cbc ! \
     nvh264dec ! glimagesink
-```
-- If you are using CTR mode and encrypting the stream multiple times and if you shuffle the decryption order, you can still get a playback for a few seconds. You will get error logs for padding as it will be incorrect, and finally your stream will error and end:
-```shell
-gst-launch-1.0 videotestsrc pattern=ball ! nvh264enc ! \
-    h264encrypt iv-seed=1869052520 key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB encryption-mode=aes-ctr ! \
-    h264encrypt iv-seed=1869052520 key=01234567012345670123456701234568 encryption-mode=aes-ctr ! \
-    h264encrypt iv-seed=1869052520 key=BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBC encryption-mode=aes-ctr ! \
-    h264parse ! video/x-h264,stream-format=avc3 ! h264parse ! video/x-h264,stream-format=byte-stream ! \
-    h264decrypt key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB encryption-mode=aes-ctr ! \
-    h264decrypt key=BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBC encryption-mode=aes-ctr ! \
-    h264decrypt key=01234567012345670123456701234568 encryption-mode=aes-ctr ! \
-    nvh264dec ! glimagesink
-...
-0:00:02.843930270 76389 0x7b2f1c002060 ERROR            h264decrypt gsth264decrypt.c:223:_remove_padding: Padding is not removed! Invalid byte found: 197
-0:00:02.843933446 76389 0x7b2f1c002060 WARN             h264decrypt gsth264decrypt.c:310:gst_h264_decrypt_decrypt_slice_nalu:<h264decrypt2> Padding is not found, data is invalid.
-0:00:02.843938626 76389 0x7b2f1c002060 WARN             h264decoder gsth264decoder.c:980:gst_h264_decoder_handle_frame_num_gap:<nvh264dec0> Invalid frame num 3, maybe frame drop
-0:00:02.844209010 76389 0x7b2f1c002060 ERROR            h264decrypt gsth264decrypt.c:278:gst_h264_decrypt_decrypt_slice_nalu:<h264decrypt1> Encrypted block size (703) is not a multiple of AES_BLOCKLEN (16). Not attempting to decrypt.
-0:00:02.844213989 76389 0x7b2f1c002060 ERROR            h264decrypt gsth264decrypt.c:202:gst_h264_decrypt_process_slice_nalu:<h264decrypt1> Failed to decrypt slice nal unit
-0:00:02.844217636 76389 0x7b2f1c002060 ERROR     h264encryptionbase gsth264encryptionbase.c:313:gst_h264_encryption_base_transform:<h264decrypt1> Subclass failed to parse slice nalu
-...
 ```
 
 ## Development Pipelines:


### PR DESCRIPTION
Changes: 
- Added link to IV (Initialization Vector) - useful for people, dont familiar with it
- One 'iv' abbreviation capitalized (iv -> IV)
- Link to 'Tiny AES in C' library not show with its name
- `Note: Use it at your own risk!` changed to GitHub's [blockqute](https://github.com/orgs/community/discussions/16925) syntax
- For code blocks added `shell` mark - for better highlighting
- For "counter mode" and "cyber block chaining mode" added "(CTR)" and "(CBC)" descriptions