### PR TITLE
h264_encrypt::_apply_padding() - fixed warning: comparison of integers of different signs

### DIFF
--- a/gst-h264-encryption/src/h264_decrypt.c
+++ b/gst-h264-encryption/src/h264_decrypt.c
@@ -246,6 +246,14 @@ static gboolean gst_h264_decrypt_decrypt_slice_nalu(GstH264Decrypt *h264decrypt,
           &payload_size)) {
     return FALSE;
   }
+  // Check end marker
+  if (nalu->data[payload_offset + payload_size - 1] != 0x80) {
+    GST_ERROR_OBJECT(h264decrypt,
+                     "Ciphertext end marker is not found. Last byte of the "
+                     "payload will not be ignored.");
+  } else {
+    payload_size--;
+  }
   // Remove emulation prevention bytes
   uint8_t *target = &nalu->data[payload_offset];
   uint8_t *read_target = &nalu->data[payload_offset];

--- a/gst-h264-encryption/src/h264_decrypt.c
+++ b/gst-h264-encryption/src/h264_decrypt.c
@@ -247,12 +247,14 @@ static gboolean gst_h264_decrypt_decrypt_slice_nalu(GstH264Decrypt *h264decrypt,
     return FALSE;
   }
   // Check end marker
-  if (nalu->data[payload_offset + payload_size - 1] != 0x80) {
+  if (nalu->data[payload_offset + payload_size - 1] != CIPHERTEXT_END_MARKER) {
     GST_ERROR_OBJECT(h264decrypt,
                      "Ciphertext end marker is not found. Last byte of the "
                      "payload will not be ignored.");
   } else {
+    // Remove end marker from the payload and overwrite it in the output buffer
     payload_size--;
+    (*dest_offset)--;
   }
   // Remove emulation prevention bytes
   uint8_t *target = &nalu->data[payload_offset];

--- a/gst-h264-encryption/src/h264_decrypt.c
+++ b/gst-h264-encryption/src/h264_decrypt.c
@@ -126,6 +126,7 @@ static void gst_h264_decrypt_init(GstH264Decrypt *h264decrypt) {
 
 static GstFlowReturn gst_h264_decrypt_prepare_output_buffer(
     GstBaseTransform *trans, GstBuffer *input, GstBuffer **outbuf) {
+  UNUSED(trans);
   gsize input_size = gst_buffer_get_size(input);
   *outbuf = gst_buffer_new_and_alloc(input_size);
   return GST_FLOW_OK;
@@ -140,6 +141,8 @@ static void gst_h264_decrypt_enter_base_transform(
 static gboolean gst_h264_decrypt_before_nalu_copy(
     GstH264EncryptionBase *encryption_base, GstH264NalUnit *src_nalu,
     GstMapInfo *dest_map_info, size_t *dest_offset, gboolean *copy) {
+  UNUSED(dest_map_info);
+  UNUSED(dest_offset);
   *copy = TRUE;
   GstH264Decrypt *h264decrypt = GST_H264_DECRYPT(encryption_base);
   if (h264decrypt->found_iv_sei) {
@@ -188,6 +191,7 @@ static gboolean gst_h264_decrypt_before_nalu_copy(
 static gboolean gst_h264_decrypt_process_slice_nalu(
     GstH264EncryptionBase *encryption_base, GstH264NalUnit *dest_nalu,
     GstMapInfo *dest_map_info, size_t *dest_offset) {
+  UNUSED(dest_map_info);
   GstH264Decrypt *h264decrypt = GST_H264_DECRYPT(encryption_base);
   if (G_UNLIKELY(!h264decrypt->found_iv_sei)) {
     GST_ERROR_OBJECT(

--- a/gst-h264-encryption/src/h264_decrypt.h
+++ b/gst-h264-encryption/src/h264_decrypt.h
@@ -34,7 +34,7 @@
 
 G_BEGIN_DECLS
 
-GST_ELEMENT_REGISTER_DECLARE(h264decrypt);
+GST_ELEMENT_REGISTER_DECLARE(h264decrypt)
 #define GST_TYPE_H264_DECRYPT (gst_h264_decrypt_get_type())
 G_DECLARE_FINAL_TYPE(GstH264Decrypt, gst_h264_decrypt, GST, H264_DECRYPT,
                      GstH264EncryptionBase)

--- a/gst-h264-encryption/src/h264_encrypt.c
+++ b/gst-h264-encryption/src/h264_encrypt.c
@@ -301,7 +301,8 @@ static GstMemory *gst_h264_encrypt_create_iv_sei_memory(
  *
  * If returns 0, max size was less than required bytes and nothing is written.
  */
-inline static gint _apply_padding(uint8_t *data, size_t size, size_t max_size) {
+inline static size_t _apply_padding(uint8_t *data, size_t size,
+                                    size_t max_size) {
   size_t i;
   size_t padding_byte_count = AES_BLOCKLEN - (size % AES_BLOCKLEN);
   if (padding_byte_count + size >= max_size) {
@@ -333,7 +334,7 @@ static gboolean gst_h264_encrypt_encrypt_slice_nalu(GstH264Encrypt *h264encrypt,
                    "Encrypting nal unit of type %d offset %ld size %ld",
                    nalu->type, payload_offset, payload_size);
   // Apply padding
-  int padding_byte_count =
+  size_t padding_byte_count =
       _apply_padding(&nalu->data[payload_offset], payload_size,
                      map_info->maxsize - payload_offset);
   if (G_UNLIKELY(padding_byte_count == 0)) {

--- a/gst-h264-encryption/src/h264_encrypt.c
+++ b/gst-h264-encryption/src/h264_encrypt.c
@@ -300,9 +300,9 @@ static GstMemory *gst_h264_encrypt_create_iv_sei_memory(
  *
  * If returns 0, max size was less than required bytes and nothing is written.
  */
-inline static gint _apply_padding(uint8_t *data, size_t size, size_t max_size) {
-  int i;
-  size_t padding_byte_count = AES_BLOCKLEN - (size % AES_BLOCKLEN);
+inline static gsize _apply_padding(guint8 *data, gsize size, gsize max_size) {
+  gsize i;
+  gsize padding_byte_count = AES_BLOCKLEN - (size % AES_BLOCKLEN);
   if (padding_byte_count + size >= max_size) {
     return 0;
   }
@@ -332,8 +332,8 @@ static gboolean gst_h264_encrypt_encrypt_slice_nalu(GstH264Encrypt *h264encrypt,
                    "Encrypting nal unit of type %d offset %ld size %ld",
                    nalu->type, payload_offset, payload_size);
   // Apply padding
-  int padding_byte_count = _apply_padding(&nalu->data[payload_offset],
-                                          payload_size, map_info->maxsize);
+  gsize padding_byte_count = _apply_padding(&nalu->data[payload_offset],
+                                            payload_size, map_info->maxsize);
   if (G_UNLIKELY(padding_byte_count == 0)) {
     GST_ERROR_OBJECT(h264encrypt, "Not enough space for padding!");
     return FALSE;

--- a/gst-h264-encryption/src/h264_encrypt.c
+++ b/gst-h264-encryption/src/h264_encrypt.c
@@ -401,7 +401,7 @@ static gboolean gst_h264_encrypt_encrypt_slice_nalu(GstH264Encrypt *h264encrypt,
                      "ciphertext end marker");
     return FALSE;
   }
-  target[j] = 0x80;
+  target[j] = CIPHERTEXT_END_MARKER;
   (*dest_offset)++;
   return TRUE;
 }

--- a/gst-h264-encryption/src/h264_encrypt.c
+++ b/gst-h264-encryption/src/h264_encrypt.c
@@ -197,7 +197,7 @@ void gst_h264_encrypt_enter_base_transform(
  * changed too
  */
 static inline gboolean is_iv_sei(void *sei_payload, size_t payload_size) {
-  const int signature_size = sizeof(GST_H264_ENCRYPT_IV_SEI_SIGNATURE) - 1;
+  size_t signature_size = sizeof(GST_H264_ENCRYPT_IV_SEI_SIGNATURE) - 1;
   return payload_size >= signature_size &&
          memcmp(sei_payload, GST_H264_ENCRYPT_IV_SEI_SIGNATURE,
                 signature_size) == 0;
@@ -268,6 +268,7 @@ static void gst_h264_encrypt_init(GstH264Encrypt *h264encrypt) {
  */
 static GstFlowReturn gst_h264_encrypt_prepare_output_buffer(
     GstBaseTransform *trans, GstBuffer *input, GstBuffer **outbuf) {
+  UNUSED(trans);
   // TODO Calculate buffer size better
   gsize input_size = gst_buffer_get_size(input);
   // Also account for SEI, changable AES_BLOCKLEN and emulation bytes
@@ -300,9 +301,9 @@ static GstMemory *gst_h264_encrypt_create_iv_sei_memory(
  *
  * If returns 0, max size was less than required bytes and nothing is written.
  */
-inline static gsize _apply_padding(guint8 *data, gsize size, gsize max_size) {
-  gsize i;
-  gsize padding_byte_count = AES_BLOCKLEN - (size % AES_BLOCKLEN);
+inline static gint _apply_padding(uint8_t *data, size_t size, size_t max_size) {
+  size_t i;
+  size_t padding_byte_count = AES_BLOCKLEN - (size % AES_BLOCKLEN);
   if (padding_byte_count + size >= max_size) {
     return 0;
   }

--- a/gst-h264-encryption/src/h264_encrypt.h
+++ b/gst-h264-encryption/src/h264_encrypt.h
@@ -62,7 +62,7 @@ G_BEGIN_DECLS
   }                                                                           \
   G_GNUC_END_IGNORE_DEPRECATIONS
 
-GST_ELEMENT_REGISTER_DECLARE(h264encrypt);
+GST_ELEMENT_REGISTER_DECLARE(h264encrypt)
 #define GST_TYPE_H264_ENCRYPT (gst_h264_encrypt_get_type())
 G_DECLARE_TYPE_STRUCTURES(GstH264Encrypt, gst_h264_encrypt, GST, H264_ENCRYPT,
                           GstH264EncryptionBase)

--- a/gst-h264-encryption/src/h264_encryption_base.c
+++ b/gst-h264-encryption/src/h264_encryption_base.c
@@ -326,6 +326,8 @@ static GstFlowReturn gst_h264_encryption_base_transform(GstBaseTransform *base,
   }
   gst_buffer_unmap(inbuf, &map_info);
   gst_buffer_unmap(outbuf, &dest_map_info);
+  // Set size of the output buffer to "dest_offset" to discard
+  // unused but allocated bytes.
   if (G_UNLIKELY(!gst_buffer_resize_range(outbuf, 0, -1, 0, dest_offset))) {
     GST_ERROR_OBJECT(base, "Unable to set buffer size!");
     return GST_FLOW_ERROR;

--- a/gst-h264-encryption/src/h264_encryption_base.c
+++ b/gst-h264-encryption/src/h264_encryption_base.c
@@ -326,7 +326,10 @@ static GstFlowReturn gst_h264_encryption_base_transform(GstBaseTransform *base,
   }
   gst_buffer_unmap(inbuf, &map_info);
   gst_buffer_unmap(outbuf, &dest_map_info);
-  gst_buffer_set_size(outbuf, dest_offset);
+  if (G_UNLIKELY(!gst_buffer_resize_range(outbuf, 0, -1, 0, dest_offset))) {
+    GST_ERROR_OBJECT(base, "Unable to set buffer size!");
+    return GST_FLOW_ERROR;
+  }
   return GST_FLOW_OK;
 error: {
   gst_buffer_unmap(inbuf, &map_info);

--- a/gst-h264-encryption/src/h264_encryption_base.h
+++ b/gst-h264-encryption/src/h264_encryption_base.h
@@ -33,6 +33,8 @@
 
 G_BEGIN_DECLS
 
+#define CIPHERTEXT_END_MARKER 0x80
+
 #define IS_SLICE_NALU(nalu_type) \
   (nalu_type >= GST_H264_NAL_SLICE && nalu_type <= GST_H264_NAL_SLICE_IDR)
 

--- a/gst-h264-encryption/src/h264_encryption_base.h
+++ b/gst-h264-encryption/src/h264_encryption_base.h
@@ -33,6 +33,12 @@
 
 G_BEGIN_DECLS
 
+/**
+ * Ciphertext may end with a null-byte and this null-byte is discarded
+ * according to ITU-T Rec. H.264 (05/2003) Section B.2 point 5.
+ * To avoid this, we always put a marker at the end of the ciphertext,
+ * whose value is defined below. Any byte greater than 0x03 should be ok.
+ */
 #define CIPHERTEXT_END_MARKER 0x80
 
 #define IS_SLICE_NALU(nalu_type) \

--- a/gst-h264-encryption/src/h264_encryption_base.h
+++ b/gst-h264-encryption/src/h264_encryption_base.h
@@ -40,6 +40,8 @@ G_BEGIN_DECLS
  * whose value is defined below. Any byte greater than 0x03 should be ok.
  */
 #define CIPHERTEXT_END_MARKER 0x80
+// Fix unused variable warnings
+#define UNUSED(x) (void)(x)
 
 #define IS_SLICE_NALU(nalu_type) \
   (nalu_type >= GST_H264_NAL_SLICE && nalu_type <= GST_H264_NAL_SLICE_IDR)

--- a/gst-h264-encryption/src/h264_encryption_plugin.h
+++ b/gst-h264-encryption/src/h264_encryption_plugin.h
@@ -51,7 +51,14 @@ G_BEGIN_DECLS
 
 // Has to be 16 bytes, excluding the null byte
 #define GST_H264_ENCRYPT_IV_SEI_UUID "GSTH264ENCRYPTIV"
-// NOTE: If IV SEI payload size changes, you need to change the third byte below
+/**
+ * NOTE: If IV SEI payload size changes, you need to change the third byte
+ * below.
+ *
+ * Third byte is the size of the NAL Unit payload and it is calculated as
+ * 16 bytes for user data unregistered SEI UUID plus size of SEI payload.
+ * IV is the payload of the SEI and it is of size AES_BLOCKLEN.
+ */
 #define GST_H264_ENCRYPT_IV_SEI_SIGNATURE \
   "\x06\x05\x20" GST_H264_ENCRYPT_IV_SEI_UUID
 

--- a/gst-h264-encryption/src/h264_encryption_types.c
+++ b/gst-h264-encryption/src/h264_encryption_types.c
@@ -52,13 +52,18 @@ static gboolean hex2bytes(const char *str, uint8_t *bytes, size_t byte_count) {
   }                                                                           \
   static void register_##struct_name##_deserialization_func(GType type) {     \
     static GstValueTable table = {                                            \
-        G_TYPE_NONE, NULL, NULL,                                              \
-        (GstValueDeserializeFunc)(function_name_prefix##_##deserialize)};     \
+        G_TYPE_NONE,                                                          \
+        NULL,                                                                 \
+        NULL,                                                                 \
+        (GstValueDeserializeFunc)(function_name_prefix##_##deserialize),      \
+        (GstValueDeserializeWithPSpecFunc)NULL,                               \
+        {NULL}};                                                              \
     table.type = type;                                                        \
     gst_value_register(&table);                                               \
   }                                                                           \
   G_DEFINE_BOXED_TYPE_WITH_CODE(                                              \
-      struct_name, function_name_prefix, function_name_prefix##_##copy,       \
+      struct_name, function_name_prefix,                                      \
+      (GBoxedCopyFunc)function_name_prefix##_##copy,                          \
       function_name_prefix##_##free,                                          \
       register_##struct_name##_deserialization_func(g_define_type_id))
 


### PR DESCRIPTION
`gcc 13.2.0` produces the next warning: `comparison of integers of different signs: 'int' and 'size_t'` (since `i` is `int`, and compared over `size_t` inside `for` loop: `i < paddint_byte_count`). This small PR fixes it.

I also replaced `uint8_t` and `size_t` by equivalent types: `guint8` and `gsize`, due to passed arguments types:
- `&naul->data[payload_offset]` is `guint8*`
- `payload_size`, `map_info->maxsize` are `gsize`