### PR TITLE
h264_encrypt::gst_h264_encrypt_set_property() - fixed warning: label followed by a declaration is a C23 extension

### DIFF
--- a/gst-h264-encryption/src/h264_encrypt.c
+++ b/gst-h264-encryption/src/h264_encrypt.c
@@ -159,10 +159,10 @@ static void gst_h264_encrypt_set_property(GObject *object, guint prop_id,
                                           GParamSpec *pspec) {
   GstH264Encrypt *h264encrypt = GST_H264_ENCRYPT(object);
   switch (prop_id) {
-    case PROP_IV_SEED:
+    case PROP_IV_SEED: {
       guint seed = g_value_get_uint(value);
       gst_h264_encrypt_set_random_iv_seed(h264encrypt, seed);
-      break;
+    } break;
     default:
       G_OBJECT_CLASS(gst_h264_encrypt_parent_class)
           ->set_property(object, prop_id, value, pspec);


### PR DESCRIPTION
`gcc 13.2.0` produces the next warning: `Label followed by a declaration is a C23 extension. 

Between 2 possible ways to fix it:
1. Declare `seed` before switch/case, and assign to it `g_value_get_uint(value)` result
2. Wrap `case PROP_IV_SEED` by brackets, to make separated scope, that begins from `seed` declaration & initializion

I choosed second way for clarity.